### PR TITLE
feat(interactions): add paginated user favorites endpoint

### DIFF
--- a/database/migrations/add-favorites-pagination-index.sql
+++ b/database/migrations/add-favorites-pagination-index.sql
@@ -1,0 +1,4 @@
+-- Adiciona um índice composto para suportar a paginação por cursor na tabela favorites.
+-- Isso previne a ocorrência de "filesort" ao ordenar os favoritos por data de criação.
+
+CREATE INDEX IDX_FAVORITES_PAGINATION ON favorites (userId, createdAt DESC, bookId DESC);

--- a/src/interactions/application/ports/favorite-repository.port.ts
+++ b/src/interactions/application/ports/favorite-repository.port.ts
@@ -7,4 +7,10 @@ export interface FavoriteRepository {
 	delete(userId: UserId, bookId: BookId): Promise<void>;
 	isFavorite(userId: UserId, bookId: BookId): Promise<boolean>;
 	findByUser(userId: UserId): Promise<Favorite[]>;
+	findPaginatedByUser(
+		userId: UserId,
+		limit: number,
+		cursorCreatedAt?: Date,
+		cursorBookId?: string,
+	): Promise<Favorite[]>;
 }

--- a/src/interactions/application/use-cases/get-favorites.use-case.ts
+++ b/src/interactions/application/use-cases/get-favorites.use-case.ts
@@ -1,0 +1,69 @@
+import { FavoriteRepository } from '@/interactions/application/ports/favorite-repository.port';
+import { Favorite } from '@/interactions/domain/entities/favorite';
+import { UserId } from '@common/domain/value-objects/user-id.vo';
+import { Inject, Injectable } from '@nestjs/common';
+import { CursorPageDto } from 'src/common/pagination/cursor-page.dto';
+import {
+	decodeCursorPayload,
+	encodeCursorPayload,
+} from 'src/common/pagination/cursor.utils';
+
+type FavoritesCursorPayload = {
+	createdAt: string;
+	bookId: string;
+};
+
+@Injectable()
+export class GetFavoritesUseCase {
+	constructor(
+		@Inject('FavoriteRepository')
+		private readonly favoriteRepository: FavoriteRepository,
+	) {}
+
+	async execute(
+		userId: UserId,
+		limit: number,
+		cursor?: string,
+	): Promise<CursorPageDto<Favorite>> {
+		let cursorCreatedAt: Date | undefined;
+		let cursorBookId: string | undefined;
+
+		if (cursor) {
+			const decoded = decodeCursorPayload<FavoritesCursorPayload>(cursor);
+			if (
+				decoded &&
+				typeof decoded.createdAt === 'string' &&
+				typeof decoded.bookId === 'string'
+			) {
+				const parsedDate = new Date(decoded.createdAt);
+				if (!Number.isNaN(parsedDate.getTime())) {
+					cursorCreatedAt = parsedDate;
+					cursorBookId = decoded.bookId;
+				}
+			}
+		}
+
+		const favorites = await this.favoriteRepository.findPaginatedByUser(
+			userId,
+			limit,
+			cursorCreatedAt,
+			cursorBookId,
+		);
+
+		const hasNextPage = favorites.length > limit;
+		const data = hasNextPage ? favorites.slice(0, limit) : favorites;
+		const lastItem = data[data.length - 1];
+
+		const nextCursor =
+			hasNextPage && lastItem
+				? encodeCursorPayload({
+						createdAt: lastItem
+							.toSnapshot()
+							.createdAt.toISOString(),
+						bookId: lastItem.toSnapshot().bookId,
+					})
+				: null;
+
+		return new CursorPageDto(data, nextCursor, hasNextPage);
+	}
+}

--- a/src/interactions/application/use-cases/get-favorites.use-case.ts
+++ b/src/interactions/application/use-cases/get-favorites.use-case.ts
@@ -25,29 +25,13 @@ export class GetFavoritesUseCase {
 		limit: number,
 		cursor?: string,
 	): Promise<CursorPageDto<Favorite>> {
-		let cursorCreatedAt: Date | undefined;
-		let cursorBookId: string | undefined;
-
-		if (cursor) {
-			const decoded = decodeCursorPayload<FavoritesCursorPayload>(cursor);
-			if (
-				decoded &&
-				typeof decoded.createdAt === 'string' &&
-				typeof decoded.bookId === 'string'
-			) {
-				const parsedDate = new Date(decoded.createdAt);
-				if (!Number.isNaN(parsedDate.getTime())) {
-					cursorCreatedAt = parsedDate;
-					cursorBookId = decoded.bookId;
-				}
-			}
-		}
+		const parsedCursor = this.parseCursor(cursor);
 
 		const favorites = await this.favoriteRepository.findPaginatedByUser(
 			userId,
 			limit,
-			cursorCreatedAt,
-			cursorBookId,
+			parsedCursor?.createdAt,
+			parsedCursor?.bookId,
 		);
 
 		const hasNextPage = favorites.length > limit;
@@ -65,5 +49,32 @@ export class GetFavoritesUseCase {
 				: null;
 
 		return new CursorPageDto(data, nextCursor, hasNextPage);
+	}
+
+	private parseCursor(
+		cursor?: string,
+	): { createdAt?: Date; bookId?: string } | undefined {
+		if (!cursor) {
+			return undefined;
+		}
+
+		const decoded = decodeCursorPayload<FavoritesCursorPayload>(cursor);
+		if (
+			!decoded ||
+			typeof decoded.createdAt !== 'string' ||
+			typeof decoded.bookId !== 'string'
+		) {
+			return undefined;
+		}
+
+		const parsedDate = new Date(decoded.createdAt);
+		if (Number.isNaN(parsedDate.getTime())) {
+			return undefined;
+		}
+
+		return {
+			createdAt: parsedDate,
+			bookId: decoded.bookId,
+		};
 	}
 }

--- a/src/interactions/infrastructure/controllers/swagger/interactions.swagger.ts
+++ b/src/interactions/infrastructure/controllers/swagger/interactions.swagger.ts
@@ -14,3 +14,11 @@ export function ApiDocsSubscribe() {
 export function ApiDocsReview() {
 	return applyDecorators(ApiOperation({ summary: 'Review and rate a book' }));
 }
+
+export function ApiDocsGetFavorites() {
+	return applyDecorators(
+		ApiOperation({
+			summary: 'Get paginated favorite books for the current user',
+		}),
+	);
+}

--- a/src/interactions/infrastructure/controllers/user-interactions.controller.ts
+++ b/src/interactions/infrastructure/controllers/user-interactions.controller.ts
@@ -14,18 +14,22 @@ import {
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { CursorPageDto } from 'src/common/pagination/cursor-page.dto';
+import { PermissionsGuard } from 'src/users/application/services/permissions.guard';
+import { Permissions } from 'src/users/domain/decorators/permissions.decorator';
+import { PermissionsEnum } from 'src/users/domain/enums/permissions.enum';
 import { FavoritesCursorOptionsDto } from '../http/dto/favorites-cursor-options.dto';
 import { ApiDocsGetFavorites } from './swagger/interactions.swagger';
 
 @ApiTags('Interactions')
 @Controller('interactions')
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, PermissionsGuard)
 @UseInterceptors(DataEnvelopeInterceptor)
 @ApiBearerAuth(SWAGGER_AUTH_SCHEME)
 export class UserInteractionsController {
 	constructor(private readonly getFavoritesUseCase: GetFavoritesUseCase) {}
 
 	@Get('favorites')
+	@Permissions(PermissionsEnum.PROFILE_VIEW)
 	@ApiDocsGetFavorites()
 	async getFavorites(
 		@CurrentUser() user: CurrentUserDto,

--- a/src/interactions/infrastructure/controllers/user-interactions.controller.ts
+++ b/src/interactions/infrastructure/controllers/user-interactions.controller.ts
@@ -29,7 +29,7 @@ export class UserInteractionsController {
 	constructor(private readonly getFavoritesUseCase: GetFavoritesUseCase) {}
 
 	@Get('favorites')
-	@Permissions(PermissionsEnum.PROFILE_VIEW)
+	@Permissions(PermissionsEnum.INTERACTIONS_MANAGE)
 	@ApiDocsGetFavorites()
 	async getFavorites(
 		@CurrentUser() user: CurrentUserDto,

--- a/src/interactions/infrastructure/controllers/user-interactions.controller.ts
+++ b/src/interactions/infrastructure/controllers/user-interactions.controller.ts
@@ -1,0 +1,47 @@
+import { GetFavoritesUseCase } from '@/interactions/application/use-cases/get-favorites.use-case';
+import { CurrentUserDto } from '@auth/application/dto/current-user.dto';
+import { CurrentUser } from '@auth/infrastructure/framework/current-user.decorator';
+import { JwtAuthGuard } from '@auth/infrastructure/framework/jwt-auth.guard';
+import { UserId } from '@common/domain/value-objects/user-id.vo';
+import { DataEnvelopeInterceptor } from '@common/interceptors/data-envelope.interceptor';
+import { SWAGGER_AUTH_SCHEME } from '@common/swagger/swagger-auth.constants';
+import {
+	Controller,
+	Get,
+	Query,
+	UseGuards,
+	UseInterceptors,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { CursorPageDto } from 'src/common/pagination/cursor-page.dto';
+import { FavoritesCursorOptionsDto } from '../http/dto/favorites-cursor-options.dto';
+import { ApiDocsGetFavorites } from './swagger/interactions.swagger';
+
+@ApiTags('Interactions')
+@Controller('interactions')
+@UseGuards(JwtAuthGuard)
+@UseInterceptors(DataEnvelopeInterceptor)
+@ApiBearerAuth(SWAGGER_AUTH_SCHEME)
+export class UserInteractionsController {
+	constructor(private readonly getFavoritesUseCase: GetFavoritesUseCase) {}
+
+	@Get('favorites')
+	@ApiDocsGetFavorites()
+	async getFavorites(
+		@CurrentUser() user: CurrentUserDto,
+		@Query() options: FavoritesCursorOptionsDto,
+	) {
+		const userId = UserId.create(user.userId);
+		const page = await this.getFavoritesUseCase.execute(
+			userId,
+			options.limit,
+			options.cursor,
+		);
+
+		return new CursorPageDto(
+			page.data.map((f) => f.toSnapshot()),
+			page.nextCursor,
+			page.hasNextPage,
+		);
+	}
+}

--- a/src/interactions/infrastructure/database/entities/favorite.entity.ts
+++ b/src/interactions/infrastructure/database/entities/favorite.entity.ts
@@ -3,12 +3,14 @@ import { User } from '@users/infrastructure/database/entities/user.entity';
 import {
 	CreateDateColumn,
 	Entity,
+	Index,
 	JoinColumn,
 	ManyToOne,
 	PrimaryColumn,
 } from 'typeorm';
 
 @Entity('favorites')
+@Index('IDX_FAVORITES_PAGINATION', ['userId', 'createdAt', 'bookId'])
 export class FavoriteEntity {
 	@PrimaryColumn()
 	userId: string;

--- a/src/interactions/infrastructure/database/repositories/typeorm-favorite.repository.ts
+++ b/src/interactions/infrastructure/database/repositories/typeorm-favorite.repository.ts
@@ -40,4 +40,32 @@ export class TypeOrmFavoriteRepository implements FavoriteRepository {
 		});
 		return entities.map((e) => Favorite.restore(e));
 	}
+
+	async findPaginatedByUser(
+		userId: UserId,
+		limit: number,
+		cursorCreatedAt?: Date,
+		cursorBookId?: string,
+	): Promise<Favorite[]> {
+		const qb = this.repository
+			.createQueryBuilder('favorite')
+			.where('favorite.userId = :userId', { userId: userId.toString() })
+			.orderBy('favorite.createdAt', 'DESC')
+			.addOrderBy('favorite.bookId', 'DESC');
+
+		if (cursorCreatedAt && cursorBookId) {
+			qb.andWhere(
+				'(favorite.createdAt < :cursorCreatedAt OR (favorite.createdAt = :cursorCreatedAt AND favorite.bookId < :cursorBookId))',
+				{
+					cursorCreatedAt,
+					cursorBookId,
+				},
+			);
+		}
+
+		qb.take(limit + 1);
+
+		const entities = await qb.getMany();
+		return entities.map((e) => Favorite.restore(e));
+	}
 }

--- a/src/interactions/infrastructure/http/dto/favorites-cursor-options.dto.ts
+++ b/src/interactions/infrastructure/http/dto/favorites-cursor-options.dto.ts
@@ -1,0 +1,25 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+
+export class FavoritesCursorOptionsDto {
+	@ApiPropertyOptional({
+		description: 'Cursor para a próxima página (base64)',
+	})
+	@IsOptional()
+	@IsString()
+	cursor?: string;
+
+	@ApiPropertyOptional({
+		description: 'Limite de itens por página',
+		default: 20,
+		minimum: 1,
+		maximum: 100,
+	})
+	@IsOptional()
+	@Type(() => Number)
+	@IsInt()
+	@Min(1)
+	@Max(100)
+	limit = 20;
+}

--- a/src/interactions/interactions.module.ts
+++ b/src/interactions/interactions.module.ts
@@ -3,9 +3,11 @@ import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersModule } from '@users/users.module';
 import { FavoriteBookUseCase } from './application/use-cases/favorite-book.use-case';
+import { GetFavoritesUseCase } from './application/use-cases/get-favorites.use-case';
 import { ReviewBookUseCase } from './application/use-cases/review-book.use-case';
 import { SubscribeToBookUseCase } from './application/use-cases/subscribe-to-book.use-case';
 import { InteractionsController } from './infrastructure/controllers/interactions.controller';
+import { UserInteractionsController } from './infrastructure/controllers/user-interactions.controller';
 import { FavoriteEntity } from './infrastructure/database/entities/favorite.entity';
 import { ReviewEntity } from './infrastructure/database/entities/review.entity';
 import { SubscriptionEntity } from './infrastructure/database/entities/subscription.entity';
@@ -24,7 +26,7 @@ import { NotificationEvents } from './infrastructure/events/notification.events'
 			ReviewEntity,
 		]),
 	],
-	controllers: [InteractionsController],
+	controllers: [InteractionsController, UserInteractionsController],
 	providers: [
 		{
 			provide: 'FavoriteRepository',
@@ -39,6 +41,7 @@ import { NotificationEvents } from './infrastructure/events/notification.events'
 			useClass: TypeOrmReviewRepository,
 		},
 		FavoriteBookUseCase,
+		GetFavoritesUseCase,
 		SubscribeToBookUseCase,
 		ReviewBookUseCase,
 		NotificationEvents,


### PR DESCRIPTION
This pull request introduces cursor-based pagination for fetching a user's favorite books, improving scalability and performance for large datasets. It adds a paginated endpoint, updates the repository and database layers to support efficient pagination, and enhances API documentation and validation.

**API Enhancements**
- Added a new endpoint `GET /interactions/favorites` in `UserInteractionsController` to retrieve a paginated list of favorite books for the current user, using cursor-based pagination. The endpoint is protected and documented with Swagger. [[1]](diffhunk://#diff-8a3a4c2e3a3268e26c1a01a95371823c870d291f67c5d2bd98af1e908fbe5a59R1-R47) [[2]](diffhunk://#diff-967718f6126de31a30d87545170e02a655a5d5e8cb17d5aa21f0e57cda89ca4fR17-R24)
- Introduced `FavoritesCursorOptionsDto` for validating and documenting pagination query parameters (`cursor`, `limit`).

**Business Logic & Repository Layer**
- Implemented `GetFavoritesUseCase` to handle cursor-based pagination logic, including cursor encoding/decoding and page metadata.
- Extended `FavoriteRepository` and its TypeORM implementation to support `findPaginatedByUser`, which efficiently fetches favorites based on cursor position and limit. [[1]](diffhunk://#diff-1a41677c925550051d7c2c97d1516160261d05b406f79ffa1681aafb774555e0R10-R15) [[2]](diffhunk://#diff-91794cbceee01a4a49c8e410a201ae81d02f8c4220b6b66ec821500e10aec729R43-R70)

**Database & Entity Updates**
- Added a composite index (`userId`, `createdAt DESC`, `bookId DESC`) on the `favorites` table to optimize cursor-based pagination queries and prevent full table scans. [[1]](diffhunk://#diff-699b783ba4c8e3d5126bd9f956289f8cdb7f09a83f04793a27deee10c696ba7aR1-R4) [[2]](diffhunk://#diff-8605f8bd3c447541c6087ae8ad9611a327a19a086345ff4cfbd079e00d3197eaR6-R13)

**Module Wiring**
- Registered the new controller and use case in the `InteractionsModule` to ensure dependency injection and routing work as expected. [[1]](diffhunk://#diff-025bc5fecffeaba1b3b169cf64e61356b75eb106c36bdc6a147cfd77f350e533R6-R10) [[2]](diffhunk://#diff-025bc5fecffeaba1b3b169cf64e61356b75eb106c36bdc6a147cfd77f350e533L27-R29) [[3]](diffhunk://#diff-025bc5fecffeaba1b3b169cf64e61356b75eb106c36bdc6a147cfd77f350e533R44)