### PR TITLE
fix(books): improve CJK fallback heuristic for localized titles

### DIFF
--- a/src/books/application/services/authors.service.ts
+++ b/src/books/application/services/authors.service.ts
@@ -39,6 +39,9 @@ export class AuthorsService {
 			author.localizedBiographies,
 			lang,
 			null,
+			'pt-BR',
+			// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+			(item: any) => item.biography,
 		);
 		if (bestBio) {
 			author.biography = bestBio.biography;

--- a/src/books/application/services/book-query.service.ts
+++ b/src/books/application/services/book-query.service.ts
@@ -133,9 +133,6 @@ export class BookQueryService {
 		}
 	}
 
-	/**
-	 * Mapeia e resolve campos localizados para um livro
-	 */
 	private mapBookLocalizations(book: Book, targetLang?: string): Book {
 		const lang = targetLang || 'pt-BR';
 
@@ -144,6 +141,9 @@ export class BookQueryService {
 			book.alternativeTitles,
 			lang,
 			book.originalLanguageCode,
+			'pt-BR',
+			// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+			(item: any) => item.title,
 		);
 		if (bestTitle) {
 			book.title = bestTitle.title;
@@ -154,6 +154,9 @@ export class BookQueryService {
 			book.localizedDescriptions,
 			lang,
 			book.originalLanguageCode,
+			'pt-BR',
+			// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+			(item: any) => item.description,
 		);
 		if (bestDesc) {
 			book.description = bestDesc.description;
@@ -166,6 +169,9 @@ export class BookQueryService {
 					author.localizedBiographies,
 					lang,
 					null,
+					'pt-BR',
+					// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+					(item: any) => item.biography,
 				);
 				if (bestBio) {
 					author.biography = bestBio.biography;

--- a/src/books/application/utils/localization.utils.ts
+++ b/src/books/application/utils/localization.utils.ts
@@ -7,12 +7,21 @@ export interface ILocalizable {
 }
 
 /**
- * Motor de resolução de conteúdo localizado.
- * Segue a hierarquia de prioridades:
+ * Verifica se a string contém caracteres do leste asiático (Kanji, Hiragana, Katakana, Hangul, etc)
+ */
+export function hasCJKCharacters(str: string): boolean {
+	return /[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uac00-\ud7af]/.test(str);
+}
+
+/**
+ * Motor de resolução de conteúdo localizado com heurísticas para alfabeto.
+ * Segue a hierarquia de prioridades adaptada para usuários ocidentais/orientais:
  * 1. Idioma alvo solicitado (targetLang)
- * 2. Idioma original da obra (originalLang)
- * 3. Idioma padrão do sistema (defaultLang)
- * 4. Qualquer conteúdo disponível
+ * 2. Idioma padrão do sistema (defaultLang)
+ * 3. Idioma ponte global (inglês), caso ocidental
+ * 4. Idioma original da obra (originalLang) - priorizando versão romanizada se usuário ocidental
+ * 5. Qualquer conteúdo sem caracteres CJK (se usuário ocidental)
+ * 6. Qualquer conteúdo disponível
  *
  * Em caso de múltiplos resultados para o mesmo idioma, o maior rank vence.
  */
@@ -21,31 +30,90 @@ export function resolveLocalizedField<T extends ILocalizable>(
 	targetLang: string | undefined | null,
 	originalLang: string | undefined | null,
 	defaultLang = 'pt-BR',
+	textExtractor?: (item: T) => string | undefined | null,
 ): T | null {
 	if (!items || items.length === 0) return null;
 
-	// Helper para filtrar e ordenar por rank (DESC)
-	const getBestMatch = (lang: string | undefined | null) => {
-		if (!lang) return null;
-		const matches = items.filter(
+	const getMatchesForLang = (lang: string) => {
+		return items.filter(
 			(item) => item.languageCode?.toLowerCase() === lang.toLowerCase(),
 		);
-		if (matches.length === 0) return null;
-		return matches.sort((a, b) => (b.rank || 0) - (a.rank || 0))[0];
+	};
+
+	const getHighestRank = (list: T[]) =>
+		list.sort((a, b) => (b.rank || 0) - (a.rank || 0))[0];
+
+	const isTargetCJK = targetLang
+		? ['ja', 'zh', 'ko'].some((code) =>
+				targetLang.toLowerCase().startsWith(code),
+			)
+		: false;
+	const preferLatinFallback = !isTargetCJK;
+
+	// Helper: filtra apenas os que NÃO tem CJK
+	const getNonCJK = (list: T[]) => {
+		if (!textExtractor) return list;
+		return list.filter((m) => {
+			const text = textExtractor(m);
+			return text ? !hasCJKCharacters(text) : false;
+		});
 	};
 
 	// 1. Tentar idioma solicitado explicitamente
-	const targetMatch = getBestMatch(targetLang);
-	if (targetMatch) return targetMatch;
+	if (targetLang) {
+		const matches = getMatchesForLang(targetLang);
+		if (matches.length > 0) {
+			if (preferLatinFallback) {
+				const nonCJK = getNonCJK(matches);
+				if (nonCJK.length > 0) return getHighestRank(nonCJK);
+			}
+			return getHighestRank(matches);
+		}
+	}
 
-	// 2. Tentar idioma original da obra
-	const originalMatch = getBestMatch(originalLang);
-	if (originalMatch) return originalMatch;
+	// 2. Tentar idioma padrão do sistema
+	if (defaultLang) {
+		const matches = getMatchesForLang(defaultLang);
+		if (matches.length > 0) {
+			if (preferLatinFallback) {
+				const nonCJK = getNonCJK(matches);
+				if (nonCJK.length > 0) return getHighestRank(nonCJK);
+			}
+			return getHighestRank(matches);
+		}
+	}
 
-	// 3. Tentar idioma padrão do sistema
-	const defaultMatch = getBestMatch(defaultLang);
-	if (defaultMatch) return defaultMatch;
+	// 3. Tentar idioma inglês como ponte global caso o usuário seja ocidental e não haja no idioma dele
+	if (preferLatinFallback) {
+		const matches = getMatchesForLang('en');
+		if (matches.length > 0) {
+			const nonCJK = getNonCJK(matches);
+			if (nonCJK.length > 0) return getHighestRank(nonCJK);
+			return getHighestRank(matches);
+		}
+	}
 
-	// 4. Fallback absoluto: o item com maior rank independente do idioma
-	return items.sort((a, b) => (b.rank || 0) - (a.rank || 0))[0];
+	// 4. Se for ocidental, procurar QUALQUER título romanizado/latino do idioma original
+	if (preferLatinFallback && originalLang) {
+		const matches = getMatchesForLang(originalLang);
+		if (matches.length > 0) {
+			const nonCJK = getNonCJK(matches);
+			if (nonCJK.length > 0) return getHighestRank(nonCJK);
+		}
+	}
+
+	// 5. Se for ocidental, procurar QUALQUER título latino em TODA A LISTA
+	if (preferLatinFallback) {
+		const nonCJKAll = getNonCJK(items);
+		if (nonCJKAll.length > 0) return getHighestRank(nonCJKAll);
+	}
+
+	// 6. Fallback final: Tentar o idioma original mesmo que seja CJK
+	if (originalLang) {
+		const matches = getMatchesForLang(originalLang);
+		if (matches.length > 0) return getHighestRank(matches);
+	}
+
+	// 7. Qualquer coisa que sobrou (Absoluto)
+	return getHighestRank([...items]);
 }

--- a/src/books/infrastructure/graphql/resolvers/book.resolver.ts
+++ b/src/books/infrastructure/graphql/resolvers/book.resolver.ts
@@ -157,6 +157,9 @@ export class BookResolver {
 				author.localizedBiographies,
 				targetLang,
 				null,
+				'pt-BR',
+				// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+				(item: any) => item.biography,
 			);
 			return {
 				...author,


### PR DESCRIPTION
This introduces a sequence that checks for non-CJK text in titles and descriptions, prioritizing romanized/Latin alphabets for western users before falling back to Katakana/Kanji.