### PR TITLE
feat(books): add admin tools to monitor stuck items and cover issues

### DIFF
--- a/src/books/application/ports/book-repository.interface.ts
+++ b/src/books/application/ports/book-repository.interface.ts
@@ -50,6 +50,10 @@ export interface IBookRepository {
 			alternativeTitles?: AlternativeTitle[];
 		}>;
 	}>;
+	findBooksWithCoverIssues(
+		page: number,
+		limit: number,
+	): Promise<[Book[], number]>;
 }
 
 export const I_BOOK_REPOSITORY = 'IBookRepository';

--- a/src/books/application/ports/chapter-repository.interface.ts
+++ b/src/books/application/ports/chapter-repository.interface.ts
@@ -45,6 +45,7 @@ export interface IChapterRepository {
 	create(data: Partial<Chapter>): Chapter;
 	merge(chapter: Chapter, data: Partial<Chapter>): Chapter;
 	createQueryBuilder(alias: string): unknown;
+	findStuckChapters(hours: number): Promise<Chapter[]>;
 }
 
 export const I_CHAPTER_REPOSITORY = 'IChapterRepository';

--- a/src/books/application/ports/cover-repository.interface.ts
+++ b/src/books/application/ports/cover-repository.interface.ts
@@ -15,6 +15,7 @@ export interface ICoverRepository {
 	updateBatch(
 		updates: { oldPath: string; newPath: string; metadata?: unknown }[],
 	): Promise<void>;
+	findStuckCovers(hours: number): Promise<Cover[]>;
 }
 
 export const I_COVER_REPOSITORY = 'ICoverRepository';

--- a/src/books/application/services/book-query.service.spec.ts
+++ b/src/books/application/services/book-query.service.spec.ts
@@ -2,6 +2,7 @@ import { MEILI_CLIENT } from '@/infrastructure/meilisearch/meilisearch.constants
 import { I_AUTHOR_REPOSITORY } from '@books/application/ports/author-repository.interface';
 import { I_BOOK_REPOSITORY } from '@books/application/ports/book-repository.interface';
 import { I_CHAPTER_REPOSITORY } from '@books/application/ports/chapter-repository.interface';
+import { I_COVER_REPOSITORY } from '@books/application/ports/cover-repository.interface';
 import { I_PAGE_REPOSITORY } from '@books/application/ports/page-repository.interface';
 import { I_SENSITIVE_CONTENT_REPOSITORY } from '@books/application/ports/sensitive-content-repository.interface';
 import { I_TAG_REPOSITORY } from '@books/application/ports/tag-repository.interface';
@@ -17,6 +18,8 @@ describe('BookQueryService (Search Optimization)', () => {
 	let service: BookQueryService;
 	let meiliClient: any;
 	let bookRepository: any;
+	let chapterRepository: any;
+	let coverRepository: any;
 	let userAccessPolicyService: any;
 
 	beforeEach(async () => {
@@ -36,12 +39,21 @@ describe('BookQueryService (Search Optimization)', () => {
 					{ id: 'book-1', title: 'Solo Leveling', covers: [] },
 				]),
 			findWithFilters: jest.fn(),
+			findBooksWithCoverIssues: jest.fn(),
 		};
 
 		userAccessPolicyService = {
 			evaluateListAccessContext: jest.fn().mockResolvedValue({
 				effectiveMaxWeightSensitiveContent: 0,
 			}),
+		};
+
+		chapterRepository = {
+			findStuckChapters: jest.fn().mockResolvedValue([]),
+		};
+
+		coverRepository = {
+			findStuckCovers: jest.fn().mockResolvedValue([]),
 		};
 
 		const module: TestingModule = await Test.createTestingModule({
@@ -57,7 +69,8 @@ describe('BookQueryService (Search Optimization)', () => {
 					provide: MediaUrlService,
 					useValue: { resolveUrl: jest.fn() },
 				},
-				{ provide: I_CHAPTER_REPOSITORY, useValue: {} },
+				{ provide: I_CHAPTER_REPOSITORY, useValue: chapterRepository },
+				{ provide: I_COVER_REPOSITORY, useValue: coverRepository },
 				{ provide: I_PAGE_REPOSITORY, useValue: {} },
 				{ provide: I_TAG_REPOSITORY, useValue: {} },
 				{ provide: I_AUTHOR_REPOSITORY, useValue: {} },
@@ -134,5 +147,42 @@ describe('BookQueryService (Search Optimization)', () => {
 
 		expect(bookRepository.findWithFilters).toHaveBeenCalled();
 		expect(result.data[0].id).toBe('fallback-book');
+	});
+
+	describe('getStuckEntities', () => {
+		it('should return stuck chapters and covers', async () => {
+			chapterRepository.findStuckChapters.mockResolvedValue([
+				{ id: 'chapter-1' },
+			]);
+			coverRepository.findStuckCovers.mockResolvedValue([
+				{ id: 'cover-1' },
+			]);
+
+			const result = await service.getStuckEntities(24);
+
+			expect(result.chapters).toEqual([{ id: 'chapter-1' }]);
+			expect(result.covers).toEqual([{ id: 'cover-1' }]);
+			expect(chapterRepository.findStuckChapters).toHaveBeenCalledWith(
+				24,
+			);
+			expect(coverRepository.findStuckCovers).toHaveBeenCalledWith(24);
+		});
+	});
+
+	describe('getBooksWithCoverIssues', () => {
+		it('should return books with missing or failed covers', async () => {
+			bookRepository.findBooksWithCoverIssues.mockResolvedValue([
+				[{ id: 'book-1', originalLanguageCode: 'ko' }],
+				1,
+			]);
+
+			const result = await service.getBooksWithCoverIssues(1, 10);
+
+			expect(result.data[0].id).toBe('book-1');
+			expect(result.metadata.total).toBe(1);
+			expect(
+				bookRepository.findBooksWithCoverIssues,
+			).toHaveBeenCalledWith(1, 10);
+		});
 	});
 });

--- a/src/books/application/services/book-query.service.ts
+++ b/src/books/application/services/book-query.service.ts
@@ -20,6 +20,10 @@ import {
 	I_CHAPTER_REPOSITORY,
 } from '@books/application/ports/chapter-repository.interface';
 import {
+	ICoverRepository,
+	I_COVER_REPOSITORY,
+} from '@books/application/ports/cover-repository.interface';
+import {
 	IPageRepository,
 	I_PAGE_REPOSITORY,
 } from '@books/application/ports/page-repository.interface';
@@ -95,6 +99,8 @@ export class BookQueryService {
 		private readonly pageRepository: IPageRepository,
 		@Inject(I_TAG_REPOSITORY)
 		private readonly tagRepository: ITagRepository,
+		@Inject(I_COVER_REPOSITORY)
+		private readonly coverRepository: ICoverRepository,
 		@Inject(I_AUTHOR_REPOSITORY)
 		private readonly authorRepository: IAuthorRepository,
 		@Inject(I_SENSITIVE_CONTENT_REPOSITORY)
@@ -598,13 +604,39 @@ export class BookQueryService {
 			};
 		};
 
-		const queues = await Promise.all([
+		return Promise.all([
 			getStats(this.bookUpdateQueue),
 			getStats(this.chapterScrapingQueue),
 			getStats(this.coverImageQueue),
 			getStats(this.fixChapterQueue),
 		]);
+	}
 
-		return { queues };
+	async getStuckEntities(hours: number) {
+		const [chapters, covers] = await Promise.all([
+			this.chapterRepository.findStuckChapters(hours),
+			this.coverRepository.findStuckCovers(hours),
+		]);
+		return { chapters, covers };
+	}
+
+	async getBooksWithCoverIssues(page: number, limit: number) {
+		const [books, total] =
+			await this.bookRepository.findBooksWithCoverIssues(page, limit);
+
+		const mappedBooks = books.map((book) => {
+			const b = this.mapBookLocalizations(book);
+			return {
+				...b,
+				cover: null,
+				coverMetadata: null,
+			} as unknown as BookListItem;
+		});
+
+		return new PageDto(mappedBooks, {
+			page,
+			total,
+			lastPage: Math.ceil(total / limit) || 1,
+		});
 	}
 }

--- a/src/books/application/services/books.service.spec.ts
+++ b/src/books/application/services/books.service.spec.ts
@@ -59,6 +59,8 @@ describe('BooksService', () => {
 		getOne: jest.fn(),
 		findAllBooks: jest.fn(),
 		findOneBook: jest.fn(),
+		getStuckEntities: jest.fn(),
+		getBooksWithCoverIssues: jest.fn(),
 	};
 
 	const mockChapterManagementService = {
@@ -315,6 +317,36 @@ describe('BooksService', () => {
 			expect(
 				mockBookBookRelationshipService.listRelationships,
 			).toHaveBeenCalledWith(idBook, query, 5, 'user-1');
+			expect(result).toEqual(mockResult);
+		});
+	});
+
+	describe('getStuckEntities', () => {
+		it('should call bookQueryService.getStuckEntities', async () => {
+			const mockResult = { chapters: [], covers: [] };
+			mockBookQueryService.getStuckEntities.mockResolvedValue(mockResult);
+
+			const result = await service.getStuckEntities(24);
+
+			expect(mockBookQueryService.getStuckEntities).toHaveBeenCalledWith(
+				24,
+			);
+			expect(result).toEqual(mockResult);
+		});
+	});
+
+	describe('getBooksWithCoverIssues', () => {
+		it('should call bookQueryService.getBooksWithCoverIssues', async () => {
+			const mockResult = { data: [], meta: {} };
+			mockBookQueryService.getBooksWithCoverIssues.mockResolvedValue(
+				mockResult,
+			);
+
+			const result = await service.getBooksWithCoverIssues(1, 10);
+
+			expect(
+				mockBookQueryService.getBooksWithCoverIssues,
+			).toHaveBeenCalledWith(1, 10);
 			expect(result).toEqual(mockResult);
 		});
 	});

--- a/src/books/application/services/books.service.ts
+++ b/src/books/application/services/books.service.ts
@@ -259,6 +259,14 @@ export class BooksService {
 		return this.bookQueryService.getQueueStats();
 	}
 
+	async getStuckEntities(hours: number) {
+		return this.bookQueryService.getStuckEntities(hours);
+	}
+
+	async getBooksWithCoverIssues(page: number, limit: number) {
+		return this.bookQueryService.getBooksWithCoverIssues(page, limit);
+	}
+
 	// ==================== GERENCIAMENTO DE CAPÍTULOS ====================
 
 	async updateChapter(idBook: string, dto: UpdateChapterDto[]) {

--- a/src/books/infrastructure/database/adapters/typeorm-book-repository.adapter.spec.ts
+++ b/src/books/infrastructure/database/adapters/typeorm-book-repository.adapter.spec.ts
@@ -14,6 +14,7 @@ describe('TypeOrmBookRepositoryAdapter', () => {
 		loadRelationCountAndMap: jest.fn().mockReturnThis(),
 		where: jest.fn().mockReturnThis(),
 		andWhere: jest.fn().mockReturnThis(),
+		orWhere: jest.fn().mockReturnThis(),
 		orderBy: jest.fn().mockReturnThis(),
 		addOrderBy: jest.fn().mockReturnThis(),
 		skip: jest.fn().mockReturnThis(),
@@ -230,6 +231,34 @@ describe('TypeOrmBookRepositoryAdapter', () => {
 
 			expect(result).toEqual(book);
 			expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith('RAND()');
+		});
+	});
+	describe('findBooksWithCoverIssues', () => {
+		it('should return books with missing or failed covers', async () => {
+			const books = [
+				{ id: '1', title: 'Book 1' },
+			] as InfrastructureBook[];
+			const total = 1;
+			mockQueryBuilder.getManyAndCount.mockResolvedValue([books, total]);
+
+			const [resultBooks, resultTotal] =
+				await adapter.findBooksWithCoverIssues(1, 10);
+
+			expect(resultBooks).toEqual(books);
+			expect(resultTotal).toBe(total);
+			expect(mockQueryBuilder.leftJoinAndSelect).toHaveBeenCalledWith(
+				'book.covers',
+				'covers',
+			);
+			expect(mockQueryBuilder.where).toHaveBeenCalledWith(
+				'covers.id IS NULL',
+			);
+			expect(mockQueryBuilder.orWhere).toHaveBeenCalledWith(
+				'covers.scrapingStatus = :status',
+				{ status: 'error' },
+			);
+			expect(mockQueryBuilder.skip).toHaveBeenCalledWith(0);
+			expect(mockQueryBuilder.take).toHaveBeenCalledWith(10);
 		});
 	});
 });

--- a/src/books/infrastructure/database/adapters/typeorm-book-repository.adapter.ts
+++ b/src/books/infrastructure/database/adapters/typeorm-book-repository.adapter.ts
@@ -570,4 +570,20 @@ export class TypeOrmBookRepositoryAdapter implements IBookRepository {
 
 		return { conflict: false };
 	}
+
+	async findBooksWithCoverIssues(
+		page: number,
+		limit: number,
+	): Promise<[DomainBook[], number]> {
+		const queryBuilder = this.repository
+			.createQueryBuilder('book')
+			.leftJoinAndSelect('book.covers', 'covers')
+			.where('covers.id IS NULL')
+			.orWhere('covers.scrapingStatus = :status', { status: 'error' })
+			.skip((page - 1) * limit)
+			.take(limit);
+
+		const [books, total] = await queryBuilder.getManyAndCount();
+		return [books as unknown as DomainBook[], total];
+	}
 }

--- a/src/books/infrastructure/database/adapters/typeorm-chapter-repository.adapter.spec.ts
+++ b/src/books/infrastructure/database/adapters/typeorm-chapter-repository.adapter.spec.ts
@@ -10,6 +10,7 @@ describe('TypeOrmChapterRepositoryAdapter', () => {
 	let _repository: jest.Mocked<Repository<InfrastructureChapter>>;
 
 	const mockQueryBuilder = {
+		leftJoinAndSelect: jest.fn().mockReturnThis(),
 		where: jest.fn().mockReturnThis(),
 		andWhere: jest.fn().mockReturnThis(),
 		select: jest.fn().mockReturnThis(),
@@ -146,6 +147,32 @@ describe('TypeOrmChapterRepositoryAdapter', () => {
 				'chapter.index > :cursorIndex',
 				{ cursorIndex: 5 },
 			);
+		});
+	});
+
+	describe('findStuckChapters', () => {
+		it('should return chapters stuck in processing or error', async () => {
+			const chapters = [
+				{ id: '1', title: 'Chapter 1' },
+			] as InfrastructureChapter[];
+			mockQueryBuilder.getMany.mockResolvedValue(chapters);
+
+			const result = await adapter.findStuckChapters(24);
+
+			expect(result).toEqual(chapters);
+			expect(mockQueryBuilder.leftJoinAndSelect).toHaveBeenCalledWith(
+				'chapter.book',
+				'book',
+			);
+			expect(mockQueryBuilder.where).toHaveBeenCalledWith(
+				'chapter.scrapingStatus IN (:...statuses)',
+				{ statuses: ['process', 'error'] },
+			);
+			expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+				'chapter.updatedAt < DATE_SUB(NOW(), INTERVAL :hours HOUR)',
+				{ hours: 24 },
+			);
+			expect(mockQueryBuilder.getMany).toHaveBeenCalled();
 		});
 	});
 });

--- a/src/books/infrastructure/database/adapters/typeorm-chapter-repository.adapter.ts
+++ b/src/books/infrastructure/database/adapters/typeorm-chapter-repository.adapter.ts
@@ -365,4 +365,24 @@ export class TypeOrmChapterRepositoryAdapter implements IChapterRepository {
 	createQueryBuilder(alias: string): unknown {
 		return this.repository.createQueryBuilder(alias);
 	}
+
+	async findStuckChapters(hours: number): Promise<DomainChapter[]> {
+		const chapters = await this.repository
+			.createQueryBuilder('chapter')
+			.leftJoinAndSelect('chapter.book', 'book')
+			.where('chapter.scrapingStatus IN (:...statuses)', {
+				statuses: ['process', 'error'],
+			})
+			.andWhere(
+				'chapter.updatedAt < DATE_SUB(NOW(), INTERVAL :hours HOUR)',
+				{ hours },
+			)
+			.getMany();
+
+		return chapters.map((c) => {
+			const result = new DomainChapter();
+			Object.assign(result, c);
+			return result;
+		});
+	}
 }

--- a/src/books/infrastructure/database/adapters/typeorm-cover-repository.adapter.spec.ts
+++ b/src/books/infrastructure/database/adapters/typeorm-cover-repository.adapter.spec.ts
@@ -1,0 +1,74 @@
+import { Cover as DomainCover } from '@books/domain/entities/cover';
+import { Cover as InfrastructureCover } from '@books/infrastructure/database/entities/cover.entity';
+import { Test, type TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { TypeOrmCoverRepositoryAdapter } from './typeorm-cover-repository.adapter';
+
+describe('TypeOrmCoverRepositoryAdapter', () => {
+	let adapter: TypeOrmCoverRepositoryAdapter;
+	let _repository: jest.Mocked<Repository<InfrastructureCover>>;
+
+	const mockQueryBuilder = {
+		leftJoinAndSelect: jest.fn().mockReturnThis(),
+		where: jest.fn().mockReturnThis(),
+		andWhere: jest.fn().mockReturnThis(),
+		getMany: jest.fn(),
+	};
+
+	const mockRepository = {
+		find: jest.fn(),
+		save: jest.fn(),
+		update: jest.fn(),
+		delete: jest.fn(),
+		create: jest.fn().mockReturnValue({}),
+		createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+	};
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [
+				TypeOrmCoverRepositoryAdapter,
+				{
+					provide: getRepositoryToken(InfrastructureCover),
+					useValue: mockRepository,
+				},
+			],
+		}).compile();
+
+		adapter = module.get<TypeOrmCoverRepositoryAdapter>(
+			TypeOrmCoverRepositoryAdapter,
+		);
+		_repository = module.get(getRepositoryToken(InfrastructureCover));
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('findStuckCovers', () => {
+		it('should return covers stuck in processing or error', async () => {
+			const covers = [
+				{ id: '1', title: 'Cover 1' },
+			] as InfrastructureCover[];
+			mockQueryBuilder.getMany.mockResolvedValue(covers);
+
+			const result = await adapter.findStuckCovers(24);
+
+			expect(result).toEqual(covers);
+			expect(mockQueryBuilder.leftJoinAndSelect).toHaveBeenCalledWith(
+				'cover.book',
+				'book',
+			);
+			expect(mockQueryBuilder.where).toHaveBeenCalledWith(
+				'cover.scrapingStatus IN (:...statuses)',
+				{ statuses: ['process', 'error'] },
+			);
+			expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+				'cover.updatedAt < DATE_SUB(NOW(), INTERVAL :hours HOUR)',
+				{ hours: 24 },
+			);
+			expect(mockQueryBuilder.getMany).toHaveBeenCalled();
+		});
+	});
+});

--- a/src/books/infrastructure/database/adapters/typeorm-cover-repository.adapter.ts
+++ b/src/books/infrastructure/database/adapters/typeorm-cover-repository.adapter.ts
@@ -166,4 +166,24 @@ export class TypeOrmCoverRepositoryAdapter implements ICoverRepository {
 
 		await this.repository.save(covers);
 	}
+
+	async findStuckCovers(hours: number): Promise<DomainCover[]> {
+		const covers = await this.repository
+			.createQueryBuilder('cover')
+			.leftJoinAndSelect('cover.book', 'book')
+			.where('cover.scrapingStatus IN (:...statuses)', {
+				statuses: ['process', 'error'],
+			})
+			.andWhere(
+				'cover.updatedAt < DATE_SUB(NOW(), INTERVAL :hours HOUR)',
+				{ hours },
+			)
+			.getMany();
+
+		return covers.map((c) => {
+			const result = new DomainCover();
+			Object.assign(result, c);
+			return result;
+		});
+	}
 }

--- a/src/books/infrastructure/http/controllers/admin-books-dashboard.controller.ts
+++ b/src/books/infrastructure/http/controllers/admin-books-dashboard.controller.ts
@@ -1,6 +1,14 @@
 import { BooksService } from '@books/application/services/books.service';
 import { CacheInterceptor, CacheTTL } from '@nestjs/cache-manager';
-import { Controller, Get, UseGuards, UseInterceptors } from '@nestjs/common';
+import {
+	Controller,
+	DefaultValuePipe,
+	Get,
+	ParseIntPipe,
+	Query,
+	UseGuards,
+	UseInterceptors,
+} from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from 'src/auth/infrastructure/framework/jwt-auth.guard';
 import { SWAGGER_AUTH_SCHEME } from 'src/common/swagger/swagger-auth.constants';
@@ -9,7 +17,9 @@ import { Permissions } from 'src/users/domain/decorators/permissions.decorator';
 import { PermissionsEnum } from 'src/users/domain/enums/permissions.enum';
 import {
 	ApiDocsDashboard,
+	ApiDocsGetBooksWithCoverIssues,
 	ApiDocsGetQueueStats,
+	ApiDocsGetStuckEntities,
 	ApiDocsProcessBookDashboard,
 } from './swagger/admin-books-dashboard.swagger';
 
@@ -41,5 +51,24 @@ export class AdminBooksDashboardController {
 	@ApiDocsGetQueueStats()
 	async getQueueStats() {
 		return this.booksService.getQueueStats();
+	}
+
+	@Get('dashboard/stuck-entities')
+	@Permissions(PermissionsEnum.BOOKS_DASHBOARD_VIEW)
+	@ApiDocsGetStuckEntities()
+	async getStuckEntities(
+		@Query('hours', new DefaultValuePipe(24), ParseIntPipe) hours: number,
+	) {
+		return this.booksService.getStuckEntities(hours);
+	}
+
+	@Get('dashboard/cover-issues')
+	@Permissions(PermissionsEnum.BOOKS_DASHBOARD_VIEW)
+	@ApiDocsGetBooksWithCoverIssues()
+	async getBooksWithCoverIssues(
+		@Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+		@Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number,
+	) {
+		return this.booksService.getBooksWithCoverIssues(page, limit);
 	}
 }

--- a/src/books/infrastructure/http/controllers/swagger/admin-books-dashboard.swagger.ts
+++ b/src/books/infrastructure/http/controllers/swagger/admin-books-dashboard.swagger.ts
@@ -128,3 +128,31 @@ export function ApiDocsGetQueueStats() {
 		}),
 	);
 }
+
+export function ApiDocsGetStuckEntities() {
+	return applyDecorators(
+		ApiOperation({
+			summary: 'Get stuck processing entities',
+			description:
+				'Retrieve chapters and covers stuck in processing or error state for a given amount of hours (Admin only)',
+		}),
+		ApiResponse({
+			status: 200,
+			description: 'Stuck entities retrieved successfully',
+		}),
+	);
+}
+
+export function ApiDocsGetBooksWithCoverIssues() {
+	return applyDecorators(
+		ApiOperation({
+			summary: 'Get books with cover issues',
+			description:
+				'Retrieve books that have no covers or their covers failed to process (Admin only)',
+		}),
+		ApiResponse({
+			status: 200,
+			description: 'Books retrieved successfully',
+		}),
+	);
+}


### PR DESCRIPTION
- Add `findStuckChapters`, `findStuckCovers`, `findBooksWithCoverIssues` to repositories

- Expose stuck entities and cover issues through BookQueryService

- Expose operations via AdminBooksDashboardController

- Include unit tests for the updated adapters and services